### PR TITLE
Add support for crates with license-file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,16 @@ pub struct CargoConfig {
     pub package: PackageConfig,
 }
 
+/// Struct representing possible license formats for Cargo.toml
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all="kebab-case")]
+pub enum CargoLicense {
+    ///SPDX identifier.
+    License(String),
+    /// Filename.
+    LicenseFile(String),
+}
+
 /// Struct representing a `Cargo.toml` file's `[package]` section
 #[derive(Clone, Debug, Deserialize)]
 pub struct PackageConfig {
@@ -32,7 +42,8 @@ pub struct PackageConfig {
     pub version: String,
 
     /// License of the package
-    pub license: String,
+    #[serde(flatten)]
+    pub license: CargoLicense,
 
     /// Homepage of the package
     pub homepage: Option<String>,

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use config::PackageConfig;
+use config::{CargoLicense, PackageConfig};
 use license;
 
 /// Default RPM spec template (in toplevel `template/spec.hbs`)
@@ -42,8 +42,12 @@ impl SpecParams {
     /// Create a new set of RPM spec template parameters
     pub fn new(package: &PackageConfig, service: Option<String>, use_sbin: bool) -> Self {
         let rpm_license = license::convert(&package.license).unwrap_or_else(|e| {
-            status_warn!("couldn't parse license {:?}: {}", &package.license, e);
-            package.license.to_owned()
+            let default_lic = match package.license {
+                CargoLicense::License(ref lic) => lic.to_owned(),
+                CargoLicense::LicenseFile(ref name) => format!("{}", name),
+            };
+            status_warn!("couldn't parse license {:?}: {}", &default_lic, e);
+            default_lic
         });
 
         Self {


### PR DESCRIPTION
Cargo supports license information either as `license` (for a license ID) or `license-file` (for a textfile in the repo), but `cargo-rpm` only works on crates that use the former. 

This attempts to solve the latter by reading from the `license-file` if it exists.   Because an RPM `License` field can only be a single line, it just takes the first line of the file.

I'm not 100% sure if this is the right approach here, so happy to be guided.  For example, we could instead specify an RPM license override in the RPM-sepcific bit of the package metadata - this is what  [`cargo-deb`](https://github.com/mmstick/cargo-deb) does.  Seems nicer to use the existing package metadata if we can though?  Also shoud we be more flexible and allow specifying which line of the license file to take?