### PR TITLE
v0.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,21 @@
+## [0.3.0] (2019-03-15)
+
+- Upgrade to Rust 2018 edition ([#19])
+- Require license to be set ([#9])
+
+## 0.2.0 (2018-06-10)
+
+- Respect `CARGO_TARGET_DIR` env var ([#1])
+
 ## 0.1.1 (2018-04-19)
 
-* Move documentation into README.md.
+- Move documentation into README.md.
 
 ## 0.1.0 (2018-04-19)
 
-* Initial release
+- Initial release
+
+[0.3.0]: https://github.com/RustRPM/cargo-rpm/pull/21
+[#19]: https://github.com/RustRPM/cargo-rpm/pull/19
+[#9]: https://github.com/RustRPM/cargo-rpm/pull/9
+[#1]: https://github.com/RustRPM/cargo-rpm/pull/1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-rpm"
 description = "Build RPMs from Rust projects using Cargo workflows"
-version     = "0.1.1"
+version     = "0.3.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 readme      = "README.md"


### PR DESCRIPTION
- Upgrade to Rust 2018 edition (#19)
- Require license to be set (#9)