### PR TITLE
Support custom targets

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -74,7 +74,8 @@ impl Builder {
         base_target_dir: &Path,
     ) -> Self {
         let mut profile = DEFAULT_PROFILE.to_owned();
-
+        // Default target is empty.
+        let mut target = "".to_owned();
         {
             let rpm_metadata = config.rpm_metadata().unwrap_or_else(|| {
                 status_error!("No [package.metadata.rpm] in Cargo.toml!");
@@ -87,10 +88,13 @@ impl Builder {
                 if let Some(ref p) = cargo.profile {
                     profile = p.to_owned();
                 }
+                if let Some(ref t) = cargo.target {
+                    target = t.to_owned();
+                }
             }
         }
 
-        let target_dir = base_target_dir.join(profile);
+        let target_dir = base_target_dir.join(target).join(profile);
         let rpmbuild_dir = target_dir.join("rpmbuild");
 
         Self {
@@ -131,6 +135,10 @@ impl Builder {
         let mut buildflags = vec![];
 
         if let Some(ref cargo) = self.rpm_metadata().cargo {
+            if let Some(ref t) = cargo.target {
+                buildflags.push(format!("--target={}", t));
+            }
+
             if let Some(ref b) = cargo.buildflags {
                 buildflags = b.clone();
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,9 @@ pub struct CargoFlags {
     /// Release profile to use (default "release")
     pub profile: Option<String>,
 
+    /// The target - defaults to the host architecture
+    pub target: Option<String>,
+
     /// Flags to pass to cargo build
     pub buildflags: Option<Vec<String>>,
 }


### PR DESCRIPTION
Allow for binaries built using a different `--target` option, like musl-backed binaries.

This is @mthebridge's #12 PR, rebased on `master` now that the build is fixed.