### PR TITLE
Add support for crates using license-file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,16 @@ pub struct CargoConfig {
     pub package: PackageConfig,
 }
 
+/// Struct representing possible license formats for Cargo.toml
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CargoLicense {
+    ///SPDX identifier.
+    License(String),
+    /// Filename.
+    LicenseFile(String),
+}
+
 /// Struct representing a `Cargo.toml` file's `[package]` section
 #[derive(Clone, Debug, Deserialize)]
 pub struct PackageConfig {
@@ -34,7 +44,8 @@ pub struct PackageConfig {
     pub version: String,
 
     /// License of the package
-    pub license: String,
+    #[serde(flatten)]
+    pub license: CargoLicense,
 
     /// Homepage of the package
     pub homepage: Option<String>,

--- a/src/license.rs
+++ b/src/license.rs
@@ -6,30 +6,48 @@
 
 #![allow(non_camel_case_types)]
 
+use crate::config::CargoLicense;
 use failure::Error;
+use std::fs;
 
 /// Convert between an SPDX 2.1 license syntax and the RPM `License` field syntax
-pub fn convert(license_string: &str) -> Result<String, Error> {
+pub fn convert(license: &CargoLicense) -> Result<String, Error> {
     let mut output = vec![];
 
-    if license_string.find('/').is_some() {
-        // Legacy syntax with '/' delimiter meaning "or"
-        for license in license_string.split('/') {
-            output.push(License::parse(license)?.as_rpm_str());
-        }
+    match license {
+        CargoLicense::License(ref s) => {
+            if s.find('/').is_some() {
+                // Legacy syntax with '/' delimiter meaning "or"
+                for lic in s.split('/') {
+                    output.push(License::parse(lic)?.as_rpm_str());
+                }
 
-        Ok(output.as_slice().join(" or "))
-    } else {
-        // Preferred syntax with "and"/"or" keywords
-        for token in license_string.split_whitespace() {
-            output.push(match token.to_lowercase().as_ref() {
-                "and" => "and",
-                "or" => "or",
-                other => License::parse(other)?.as_rpm_str(),
-            });
-        }
+                Ok(output.as_slice().join(" or "))
+            } else {
+                // Preferred syntax with "and"/"or" keywords
+                for token in s.split_whitespace() {
+                    output.push(match token.to_lowercase().as_ref() {
+                        "and" => "and",
+                        "or" => "or",
+                        other => License::parse(other)?.as_rpm_str(),
+                    });
+                }
 
-        Ok(output.as_slice().join(" "))
+                Ok(output.as_slice().join(" "))
+            }
+        }
+        CargoLicense::LicenseFile(ref path) => {
+            let license_string = fs::read_to_string(path)?;
+
+            // RPMs can only have 1 line in the license - so use the first.
+            let license_string = license_string
+                .lines()
+                .next()
+                .ok_or_else(|| format_err!("empty license file {}!", path))?
+                .to_owned();
+
+            Ok(license_string)
+        }
     }
 }
 


### PR DESCRIPTION
Use the first line of the license-file from Cargo.toml as the RPM License, if present.

This is @mthebridge's #11 rebased on master.