### PR TITLE
use cargo-release alpha version numbers if available

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -117,7 +117,8 @@ impl Archive {
         rpm_config_dir: &Path,
         target_dir: &Path,
     ) -> Result<Self, Error> {
-        let base_dir = PathBuf::from(format!("{}-{}", config.name, config.version));
+        let (version, _) = config.version();
+        let base_dir = PathBuf::from(format!("{}-{}", config.name, version));
         let rpm_metadata = config.rpm_metadata().ok_or_else(|| {
             err!(
                 ErrorKind::Config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -70,6 +70,19 @@ impl PackageConfig {
     pub fn rpm_metadata(&self) -> Option<&RpmConfig> {
         self.metadata.as_ref().and_then(|md| md.rpm.as_ref())
     }
+
+    /// Get the version and release for this package
+    pub fn version(&self) -> (String, String) {
+        let version_split: Vec<&str> = self.version.split('-').collect();
+        let version = version_split[0].into();
+        // Get the release, defaulting to 1 if there isn't one present
+        // For a pre-release version, cargo release appends -alpha.0, -beta.1, etc.
+        let release = version_split
+            .get(1)
+            .map(|rel| format!("0.{}", rel))
+            .unwrap_or_else(|| "1".into());
+        (version, release)
+    }
 }
 
 /// The `[package.metadata]` table: ignored by Cargo, but we can put stuff there

--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -5,7 +5,7 @@
 Name: {{ name }}
 Summary: {{ summary }}
 Version: @@VERSION@@
-Release: 1
+Release: @@RELEASE@@
 {{#if license ~}}
 License: {{ license }}
 {{/if ~}}


### PR DESCRIPTION
When you use cargo-release to update the version number, the next
working version winds up being something like 0.1.2-alpha.0. That is not
a valid RPM version number, though. However, you can split the version
number along the - and take the latter half as part of the release. This
change will set the version number for the RPM to be (from the example)
0.1.2 with a release of 0.alpha.0. If there is no release found in the
version number, assume a release of 1 (which will be later than the
pre-release version numbers provided by cargo-release). Fixes #3.