### PR TITLE
v0.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## [0.6.0] (2019-08-10)
+
+- Use `cargo-release` alpha version numbers if available ([#31])
+
 ## [0.5.0] (2019-08-07)
 
 - Migrate from `iq-cli` to Abscissa application framework ([#29])
@@ -25,6 +29,8 @@
 
 - Initial release
 
+[0.6.0]: https://github.com/RustRPM/cargo-rpm/pull/32
+[#31]: https://github.com/RustRPM/cargo-rpm/pull/29
 [0.5.0]: https://github.com/RustRPM/cargo-rpm/pull/30
 [#29]: https://github.com/RustRPM/cargo-rpm/pull/29
 [0.4.0]: https://github.com/RustRPM/cargo-rpm/pull/26

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "cargo-rpm"
 description = "Build RPMs from Rust projects using Cargo workflows"
-version     = "0.5.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.6.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 readme      = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/cargo-rpm/0.5.0")]
+#![doc(html_root_url = "https://docs.rs/cargo-rpm/0.6.0")]
 
 #[macro_use]
 extern crate abscissa_core;


### PR DESCRIPTION
- Use `cargo-release` alpha version numbers if available (#31)