### PR TITLE
Fix two issues with custom release/target usage

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -124,7 +124,7 @@ impl Builder {
             }
 
             if let Some(ref b) = cargo.buildflags {
-                buildflags = b.clone();
+                buildflags.append(&mut b.clone());
             }
         };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -149,7 +149,7 @@ pub fn append_rpm_metadata(
 
     // Flags to pass to cargo when doing a release
     // TODO: use serde serializer?
-    writeln!(cargo_toml, "\n[package.metadata.rpm]")?;
+    writeln!(cargo_toml, "\n[package.metadata.rpm.cargo]")?;
     writeln!(cargo_toml, "buildflags = [\"--release\"]")?;
 
     // Target files to include in an archive


### PR DESCRIPTION
1. correct default target location in Cargo.toml
2. correct buildargs target overwriting, change to appending

This often led to non-release and non targeted builds happening