### PR TITLE
Remove the assumption that service -> sbin

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -88,7 +88,7 @@ impl InitCmd {
         };
 
         // Autodetect whether to place target files in `/usr/bin` or `/usr/sbin`
-        let use_sbin = self.sbin || service_name.is_some();
+        let use_sbin = self.sbin;
 
         // Autodetect target types
         let targets = match TargetType::detect(&crate_root)? {


### PR DESCRIPTION
This doesn't really make sense, just because a binary is run as a
service doesn't mean it goes in /usr/sbin