### PR TITLE
Use cargo_metadata to detect target directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ lazy_static = "1"
 handlebars = "2"
 serde = { version = "1", features = ["serde_derive"] }
 tar = "0.4"
+cargo_metadata = "0.9"
 
 [dev-dependencies.abscissa_core]
 version = "0.4"

--- a/src/target.rs
+++ b/src/target.rs
@@ -13,20 +13,10 @@ pub fn find_dir() -> Result<PathBuf, Error> {
         return Ok(PathBuf::from(p));
     }
 
-    // Check all parents of the current directory for a target directory.
-    // We could call `cargo metadata` to find it but this is much cheaper.
-    let mut path = fs::canonicalize(".")?;
-
-    loop {
-        let target = path.join("target");
-        if target.exists() {
-            return Ok(target);
-        }
-
-        path = match path.parent() {
-            Some(p) => p.to_path_buf(),
-            None => fail!(ErrorKind::Target, "couldn't find target directory!"),
-        }
+    let mut cmd = cargo_metadata::MetadataCommand::new();
+    match cmd.exec() {
+        Ok(metadata) => Ok(metadata.target_directory),
+        Err(_) => fail!(ErrorKind::Target, "couldn't find target directory!"),
     }
 }
 


### PR DESCRIPTION
I think there are some problems about target directory detecting.
All cases can be resolved by using `cargo_metadata`.

* Clean build

The following command is failed because `target` is not found.

```
$ cargo clean
$ cargo rpm build
error: error finding target directory: target error: couldn't find target directory!
```

* Workspace

Workspace may have some `target` directories.
Of course, workspace should have single `target`, but some tools ( ex. `rls` ) generate `target` in each crates.

```
$ tree
project
|-- crate1
|   `-- target
|-- crate2
|   `-- target
`-- target 
```

* `target` outside project

If there is not `target` in project and there is `target` outside project,
a wrong directory is detected.

```
$ tree
.
|-- project
`-- target
```