### PR TITLE
Allow to supply --target, when cross compiling

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -222,7 +222,19 @@ impl Builder {
         let tmppath_macro = format!("_tmppath {}", self.rpmbuild_dir.join("tmp").display());
 
         // Calculate rpmbuild arguments
-        let args = ["-D", &topdir_macro, "-D", &tmppath_macro, "-ba", &spec_path];
+        let mut args = vec!["-D", &topdir_macro, "-D", &tmppath_macro, "-ba", &spec_path];
+
+        let arch = self
+            .config
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.rpm.as_ref())
+            .and_then(|rpm| rpm.target_architecture.as_ref());
+
+        if let Some(arch) = arch {
+            args.push("--target");
+            args.push(arch);
+        }
 
         if self.verbose {
             status_ok!("Running", "{} {}", cmd.path.display(), &args.join(" "));

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,6 +103,9 @@ pub struct RpmConfig {
 
     /// Extra files (taken from the `.rpm` directory) to include in the RPM
     pub files: Option<BTreeMap<String, FileConfig>>,
+
+    /// Target architecture passed to `rpmbuild`
+    pub target_architecture: Option<String>,
 }
 
 /// Options for creating the release artifact


### PR DESCRIPTION
This patch allows to supply `target_architecture` in `[package.metadata.rpm]`, like so:

```toml
[package.metadata.rpm]
target_architecture = "armv7hl"
```
and will run `rpmbuild` with `--target` flag. Supplying `--target` is necessary when using `cargo-rpm` for cross compiling, however it's not the most elegant solution: best case, it should be sourced from `cargo`'s `--target` somehow.

If you have a suggestion how to implement this more elegantly, I'll be happy to hear about it!