### PR TITLE
Support RPM packages with different names than the crate name

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -118,7 +118,7 @@ impl Archive {
         target_dir: &Path,
     ) -> Result<Self, Error> {
         let (version, _) = config.version();
-        let base_dir = PathBuf::from(format!("{}-{}", config.name, version));
+        let base_dir = PathBuf::from(format!("{}-{}", config.rpm_name(), version));
         let rpm_metadata = config.rpm_metadata().ok_or_else(|| {
             err!(
                 ErrorKind::Config,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -100,7 +100,7 @@ impl Builder {
         status_ok!(
             "Finished",
             "{}-{}-{}.rpm: built in {} secs",
-            self.config.name,
+            self.config.rpm_name(),
             version,
             release,
             began_at.elapsed().as_secs()
@@ -153,7 +153,7 @@ impl Builder {
         let (version, _) = self.config.version();
 
         // Build a tarball containing the RPM's contents
-        let archive_file = format!("{}-{}.tar.gz", self.config.name, version);
+        let archive_file = format!("{}-{}.tar.gz", self.config.rpm_name(), version);
         let archive_path = sources_dir.join(&archive_file);
 
         if self.verbose {
@@ -168,7 +168,7 @@ impl Builder {
     /// Render the package's RPM spec file
     fn render_spec(&self) -> Result<(), Error> {
         // Read the spec file from `.rpm`
-        let spec_filename = format!("{}.spec", self.config.name);
+        let spec_filename = format!("{}.spec", self.config.rpm_name());
         let mut spec_src = File::open(self.rpm_config_dir.join(&spec_filename))?;
         let mut spec_template = String::new();
         spec_src.read_to_string(&mut spec_template)?;
@@ -198,7 +198,7 @@ impl Builder {
     /// Run rpmbuild
     fn rpmbuild(&self) -> Result<(), Error> {
         let (version, release) = self.config.version();
-        let rpm_file = format!("{}-{}-{}.rpm", self.config.name, version, release);
+        let rpm_file = format!("{}-{}-{}.rpm", self.config.rpm_name(), version, release);
         let cmd = Rpmbuild::new(self.verbose)?;
 
         status_ok!(
@@ -217,7 +217,7 @@ impl Builder {
         env::set_current_dir(&self.rpmbuild_dir)?;
 
         // Calculate rpmbuild arguments
-        let spec_path = format!("SPECS/{}.spec", self.config.name);
+        let spec_path = format!("SPECS/{}.spec", self.config.rpm_name());
         let topdir_macro = format!("_topdir {}", self.rpmbuild_dir.display());
         let tmppath_macro = format!("_tmppath {}", self.rpmbuild_dir.join("tmp").display());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,15 @@ impl PackageConfig {
         self.metadata.as_ref().and_then(|md| md.rpm.as_ref())
     }
 
+    /// Get the RPM package name. This is either the explicitly set
+    /// `package.metadata.rpm.package` variable or defaults to the
+    /// `package.name` crate name variable.
+    pub fn rpm_name(&self) -> &str {
+        self.rpm_metadata()
+            .and_then(|r| r.package.as_ref())
+            .unwrap_or(&self.name)
+    }
+
     /// Get the version and release for this package
     pub fn version(&self) -> (String, String) {
         let version_split: Vec<&str> = self.version.split('-').collect();
@@ -95,6 +104,9 @@ pub struct PackageMetadata {
 /// Our `[package.metadata.rpm]` extension to `Cargo.toml`
 #[derive(Clone, Debug, Deserialize)]
 pub struct RpmConfig {
+    /// The RPM package name, if different from crate name
+    pub package: Option<String>,
+
     /// Options for creating the release artifact
     pub cargo: Option<CargoFlags>,
 
@@ -136,6 +148,7 @@ pub struct FileConfig {
 
 /// Render `package.metadata.rpm` section to include in Cargo.toml
 pub fn append_rpm_metadata(
+    pkg_name: &str,
     path: &Path,
     targets: &[String],
     extra_files: &[PathBuf],
@@ -146,6 +159,9 @@ pub fn append_rpm_metadata(
     status_ok!("Updating", "{}", path.canonicalize().unwrap().display());
 
     let mut cargo_toml = OpenOptions::new().append(true).open(path)?;
+
+    writeln!(cargo_toml, "\n[package.metadata.rpm]")?;
+    writeln!(cargo_toml, "package = \"{}\"", pkg_name)?;
 
     // Flags to pass to cargo when doing a release
     // TODO: use serde serializer?

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -43,7 +43,12 @@ pub struct SpecParams {
 
 impl SpecParams {
     /// Create a new set of RPM spec template parameters
-    pub fn new(package: &PackageConfig, service: Option<String>, use_sbin: bool) -> Self {
+    pub fn new(
+        pkg_name: String,
+        package: &PackageConfig,
+        service: Option<String>,
+        use_sbin: bool,
+    ) -> Self {
         let rpm_license = license::convert(&package.license).unwrap_or_else(|e| {
             let default_lic = match package.license {
                 CargoLicense::License(ref lic) => lic.to_owned(),
@@ -54,7 +59,7 @@ impl SpecParams {
         });
 
         Self {
-            name: package.name.to_owned(),
+            name: pkg_name,
             summary: package.description.to_owned(),
             license: rpm_license,
             url: package.homepage.to_owned(),
@@ -103,7 +108,7 @@ impl<'a> From<&'a PackageConfig> for ServiceParams {
         Self {
             description: package.description.to_owned(),
             /// TODO: better handling of target binaries and their paths
-            bin_path: PathBuf::from("/usr/sbin").join(&package.name),
+            bin_path: PathBuf::from("/usr/sbin").join(&package.rpm_name()),
         }
     }
 }


### PR DESCRIPTION
Solves https://github.com/RustRPM/cargo-rpm/issues/51.

Adds a `--package` to the `cargo rpm init` command to set this variable.

It's also added to `Cargo.toml` as `package.metadata.rpm.package`.