### PR TITLE
Add a --dist flag to init to add dist info to release

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -41,6 +41,10 @@ pub struct InitCmd {
     /// Path to the RPM spec template
     #[options(long = "template")]
     pub template: Option<String>,
+
+    /// Append the distribution tag to the release
+    #[options(no_short, long = "dist")]
+    pub dist: bool,
 }
 
 impl Runnable for InitCmd {
@@ -115,7 +119,7 @@ impl InitCmd {
 
         // Render `.rpm/<cratename>.spec`
         let spec_path = rpm_config_dir.join(format!("{}.spec", config.package().name));
-        let spec_params = SpecParams::new(&config.package(), service_name.clone(), use_sbin);
+        let spec_params = SpecParams::new(&config.package(), service_name.clone(), use_sbin, self.dist);
         render_spec(&spec_path, &self.template, &spec_params)?;
 
         // (Optional) Render `.rpm/<cratename>.service` (systemd service unit config)

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -39,11 +39,14 @@ pub struct SpecParams {
 
     /// Are we placing targets in sbin instead of bin?
     pub use_sbin: bool,
+
+    /// Append the build distribution to the release tag
+    pub dist: bool,
 }
 
 impl SpecParams {
     /// Create a new set of RPM spec template parameters
-    pub fn new(package: &PackageConfig, service: Option<String>, use_sbin: bool) -> Self {
+    pub fn new(package: &PackageConfig, service: Option<String>, use_sbin: bool, dist: bool) -> Self {
         let rpm_license = license::convert(&package.license).unwrap_or_else(|e| {
             let default_lic = match package.license {
                 CargoLicense::License(ref lic) => lic.to_owned(),
@@ -60,6 +63,7 @@ impl SpecParams {
             url: package.homepage.to_owned(),
             service,
             use_sbin,
+            dist: dist,
         }
     }
 

--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -5,7 +5,7 @@
 Name: {{ name }}
 Summary: {{ summary }}
 Version: @@VERSION@@
-Release: @@RELEASE@@
+Release: @@RELEASE@@{{#if dist ~}}%{?dist}{{/if ~}}
 {{#if license ~}}
 License: {{ license }}
 {{/if ~}}


### PR DESCRIPTION
I'm personally more in favor of https://github.com/RustRPM/cargo-rpm/pull/57, where this change is made compulsory.