### PR TITLE
Add dist info to release in specfile

### DIFF
--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -5,7 +5,7 @@
 Name: {{ name }}
 Summary: {{ summary }}
 Version: @@VERSION@@
-Release: @@RELEASE@@
+Release: @@RELEASE@@%{?dist}
 {{#if license ~}}
 License: {{ license }}
 {{/if ~}}


### PR DESCRIPTION
This is an alternative to https://github.com/RustRPM/cargo-rpm/pull/56, where this change is made optional.