### PR TITLE
Add .rustfmt.toml and .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+# see https://editorconfig.org for more options, and setup instructions for yours editor
+
+[*.rs]
+indent_style = space
+indent_size = 4

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+hard_tabs = false


### PR DESCRIPTION
I noticed that the CI validates the formatting. It does make sense to add a config file then.

F.e. in my personal environment, I have a non-default `~/.rustfmt.toml`.

Also, if people would be open to that, I would suggest using `use_small_heuristic = "Off"`. I do that in all my projects and it (1) create way more readable code and (2) makes it way more predictable when a line will be broken by rustfmt.