### PR TITLE
Fix error when adding a folder to `files`

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -98,7 +98,11 @@ impl ArchiveFile {
         header.set_mode(self.mode);
         header.set_cksum();
 
-        builder.append(&header, src_file)?;
+        if src_metadata.is_dir() {
+            builder.append(&header, std::io::empty())?;
+        } else {
+            builder.append(&header, src_file)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
This commit resolves the error which occurs when one of the file provided to construct the archive is indeed a directory. The error occurs because the `append` [method](https://docs.rs/tar/0.4.26/tar/struct.Builder.html#method.append) in `tar::Builder` normally read the provided data (in this case the file). I just added a condition to instead provide an empty buffer if the file is a directory.