### PR TITLE
Add support for build hooks

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -173,10 +173,10 @@ impl Builder {
     /// Launch commands after `cargo build`  
     fn build_hooks(&self) -> Result<(), Error> {
         if let Some(hooks) = self.rpm_metadata().build_hooks.as_ref() {
-            for (command, args) in hooks {
-                status_info!("Launching", "build hook `{}`", command);
+            for (cmd, args) in hooks {
+                status_info!("Launching", "build hook \"{}\"", cmd);
 
-                let status = Command::new(command)
+                let status = Command::new(cmd)
                     .args(args)
                     .stdin(Stdio::null())
                     .stdout(if self.verbose {
@@ -192,6 +192,11 @@ impl Builder {
                     .status()?;
 
                 if !status.success() {
+                    status_err!(
+                        "Failed to launch build hook \"{}\" `{}`",
+                        cmd,
+                        args.join(" ")
+                    );
                     process::exit(status.code().unwrap_or(1));
                 }
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -115,6 +115,9 @@ pub struct RpmConfig {
     /// Extra files (taken from the `.rpm` directory) to include in the RPM
     pub files: Option<BTreeMap<String, FileConfig>>,
 
+    /// Extra commands to launch after building
+    pub build_hooks: Option<BTreeMap<String, Vec<String>>>,
+
     /// Target architecture passed to `rpmbuild`
     pub target_architecture: Option<String>,
 }


### PR DESCRIPTION
This commit add the ability to use "build hooks", which are commands executed just after `cargo build`. To use them, the user have to provide the command name as the key and the arguments as an array of `String`.