### PR TITLE
Add missing post header in the spec template

### DIFF
--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -41,6 +41,7 @@ cp -a * %{buildroot}
 rm -rf %{buildroot}
 
 {{#if service ~}}
+%post
 %systemd_post {{service}}
 
 %preun


### PR DESCRIPTION
systemd_post macro should be under the %post directive in the rpm spec template.