### PR TITLE
Improvements to rust target passing and rpm target architecture determination

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -38,6 +38,9 @@ pub struct Builder {
     /// Can we assume that the project is already built?
     pub no_cargo_build: bool,
 
+    /// Rust target for cross-compilation
+    pub target: Option<String>,
+
     /// Output path for the built rpm (either a file or directory)
     pub output_path: Option<String>,
 
@@ -57,13 +60,14 @@ impl Builder {
         config: &PackageConfig,
         verbose: bool,
         no_cargo_build: bool,
+        target: Option<&String>,
         output_path: Option<&String>,
         rpm_config_dir: &Path,
         base_target_dir: &Path,
     ) -> Self {
         let mut profile = DEFAULT_PROFILE.to_owned();
-        // Default target is empty.
-        let mut target = "".to_owned();
+        let mut config_target = None;
+
         {
             let rpm_metadata = config.rpm_metadata().unwrap_or_else(|| {
                 status_err!("No [package.metadata.rpm] in Cargo.toml!");
@@ -76,19 +80,25 @@ impl Builder {
                 if let Some(ref p) = cargo.profile {
                     profile = p.to_owned();
                 }
-                if let Some(ref t) = cargo.target {
-                    target = t.to_owned();
-                }
+                config_target = cargo.target.as_ref();
             }
         }
 
-        let target_dir = base_target_dir.join(target).join(profile);
+        if target.is_some() && config_target.is_some() {
+            status_warn!("target also specified as part of [package.metadata.rpm.cargo] in Cargo.toml, but ignoring it");
+        }
+        let final_target = target.or(config_target);
+
+        let target_dir = base_target_dir
+            .join(final_target.unwrap_or(&"".to_owned())) // empty default target
+            .join(profile);
         let rpmbuild_dir = target_dir.join("rpmbuild");
 
         Self {
             config: config.clone(),
             verbose,
             no_cargo_build,
+            target: final_target.cloned(),
             output_path: output_path.cloned(),
             rpm_config_dir: rpm_config_dir.into(),
             target_dir,
@@ -130,11 +140,11 @@ impl Builder {
     fn cargo_build(&self) -> Result<(), Error> {
         let mut buildflags = vec![];
 
-        if let Some(ref cargo) = self.rpm_metadata().cargo {
-            if let Some(ref t) = cargo.target {
-                buildflags.push(format!("--target={}", t));
-            }
+        if let Some(ref t) = self.target {
+            buildflags.push(format!("--target={}", t));
+        }
 
+        if let Some(ref cargo) = self.rpm_metadata().cargo {
             if let Some(ref b) = cargo.buildflags {
                 buildflags.append(&mut b.clone());
             }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -19,6 +19,10 @@ pub struct BuildCmd {
     #[options(long = "no-cargo-build")]
     pub no_cargo_build: bool,
 
+    /// Rust target for cross-compilation
+    #[options(long = "target")]
+    pub target: Option<String>,
+
     /// Output path for the built rpm (either a file or directory)
     #[options(long = "output")]
     pub output: Option<String>,
@@ -56,6 +60,7 @@ impl Runnable for BuildCmd {
             config.package(),
             self.verbose,
             self.no_cargo_build,
+            self.target.as_ref(),
             output_path_absolute.as_ref(),
             &rpm_config_dir,
             &target_dir,

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -6,7 +6,7 @@ use crate::{
     target,
 };
 use abscissa_core::{Command, Runnable};
-use std::{path::PathBuf, process};
+use std::{env, path::PathBuf, process};
 
 /// The `cargo rpm build` subcommand
 #[derive(Command, Debug, Default, Options)]
@@ -48,10 +48,12 @@ impl Runnable for BuildCmd {
         // and if we don't do this, rpmbuild would put the rpm relative to
         // %{_topdir}, when relative paths are specified here).
         let output_path_absolute = self.output.as_ref().map(|path_string| {
-            let mut p = std::env::current_dir().unwrap_or_else(|err| {
-                status_err!("{}: {}", err, path_string);
+            let mut p = env::current_dir().unwrap_or_else(|err| {
+                status_err!("{}", err);
                 process::exit(1);
             });
+            // If path_string is already absolute, p becomes that. Otherwise
+            // current dir is prepended to the path_string.
             p.push(path_string);
             p.display().to_string()
         });

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,32 +209,3 @@ pub fn append_rpm_metadata(
 
     Ok(())
 }
-
-/// Get rpm target architecture based on the rust target
-pub fn get_target_architecture(target: &str) -> &str {
-    let mut parts = target.split('-');
-    let arch = parts.next().unwrap();
-    let abi = parts.last().unwrap_or("");
-
-    // based on the similar function from cargo-deb:
-    // https://github.com/mmstick/cargo-deb/blob/v1.23.1/src/manifest.rs#L909-L937
-    // with adjustments for valid values that `rpmbuild --target` takes
-    match (arch, abi) {
-        // https://doc.rust-lang.org/std/env/consts/constant.ARCH.html
-        // rustc --print target-list
-        // https://fedoraproject.org/wiki/Architectures
-        // https://github.com/rpm-software-management/rpm/blob/rpm-4.14.3-release/rpmrc.in#L156
-        ("mipsisa32r6", _) => "mipsr6",
-        ("mipsisa32r6el", _) => "mipsr6el",
-        ("mipsisa64r6", _) => "mips64r6",
-        ("mipsisa64r6el", _) => "mips64r6el",
-        ("powerpc", _) => "ppc",
-        ("powerpc64", _) => "ppc64",
-        ("powerpc64le", _) => "ppc64le",
-        ("riscv64gc", _) => "riscv64",
-        ("x86", _) => "i386",
-        (arm, gnueabi) if arm.starts_with("arm") && gnueabi.ends_with("hf") => "armv7hl",
-        (arm, _) if arm.starts_with("arm") => "armv7l",
-        (other_arch, _) => other_arch,
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,5 @@ pub mod license;
 mod prelude;
 pub mod rpmbuild;
 pub mod target;
+pub mod target_architecture;
 pub mod templates;

--- a/src/target_architecture.rs
+++ b/src/target_architecture.rs
@@ -1,0 +1,107 @@
+//! Derive rpm target architecture names from rust targets:
+//! https://forge.rust-lang.org/release/platform-support.html
+//! https://docs.fedoraproject.org/ro/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch01s03.html
+
+#![allow(non_camel_case_types)]
+
+use crate::error::{Error, ErrorKind};
+
+/// Target architectures for which we have a defined rpm target architecture.
+/// Only the architectures that vary in name between the rust and rpm target
+/// need to be listed here explictly (others that follow the same naming across
+/// both targets can be used as is).
+pub enum TargetArch {
+    /// mipsisa32r6
+    mipsisa32r6,
+
+    /// mipsisa32r6el
+    mipsisa32r6el,
+
+    /// mipsisa64r6
+    mipsisa64r6,
+
+    /// mipsisa64r6el
+    mipsisa64r6el,
+
+    /// powerpc
+    powerpc,
+
+    /// powerpc64
+    powerpc64,
+
+    /// powerpc64le
+    powerpc64le,
+
+    /// riscv64gc
+    riscv64gc,
+
+    /// x86
+    x86,
+
+    /// arm (hard-float)
+    arm_hf,
+
+    /// arm
+    arm,
+
+    /// for all other architectures
+    Other(String),
+}
+
+impl TargetArch {
+    /// Parse a specific rust target triple into the `TargetArch` enum
+    pub fn parse(rust_target_triple: &str) -> Result<Self, Error> {
+        let mut parts = rust_target_triple.split('-');
+        let arch = parts.next().ok_or_else(|| {
+            err!(
+                ErrorKind::Parse,
+                "no arch in the rust target {}!",
+                rust_target_triple
+            )
+        })?;
+
+        let abi = parts.last().unwrap_or("");
+
+        // https://doc.rust-lang.org/std/env/consts/constant.ARCH.html
+        // rustc --print target-list
+        Ok(match (arch, abi) {
+            ("mipsisa32r6", _) => TargetArch::mipsisa32r6,
+            ("mipsisa32r6el", _) => TargetArch::mipsisa32r6el,
+            ("mipsisa64r6", _) => TargetArch::mipsisa64r6,
+            ("mipsisa64r6el", _) => TargetArch::mipsisa64r6el,
+            ("powerpc", _) => TargetArch::powerpc,
+            ("powerpc64", _) => TargetArch::powerpc64,
+            ("powerpc64le", _) => TargetArch::powerpc64le,
+            ("riscv64gc", _) => TargetArch::riscv64gc,
+            ("x86", _) => TargetArch::x86,
+            (arm, gnueabi) if arm.starts_with("arm") && gnueabi.ends_with("hf") => {
+                TargetArch::arm_hf
+            }
+            (arm, _) if arm.starts_with("arm") => TargetArch::arm,
+            (other_arch, _) => TargetArch::Other(other_arch.to_owned()),
+        })
+    }
+
+    /// Return a rpm target architecture name
+    pub fn as_rpm_target_architecture(&self) -> &str {
+        // based on the similar function from cargo-deb:
+        // https://github.com/mmstick/cargo-deb/blob/v1.23.1/src/manifest.rs#L909-L937
+        // with adjustments for valid values that `rpmbuild --target` takes
+        match self {
+            // https://fedoraproject.org/wiki/Architectures
+            // https://github.com/rpm-software-management/rpm/blob/rpm-4.14.3-release/rpmrc.in#L156
+            TargetArch::mipsisa32r6 => "mipsr6",
+            TargetArch::mipsisa32r6el => "mipsr6el",
+            TargetArch::mipsisa64r6 => "mips64r6",
+            TargetArch::mipsisa64r6el => "mips64r6el",
+            TargetArch::powerpc => "ppc",
+            TargetArch::powerpc64 => "ppc64",
+            TargetArch::powerpc64le => "ppc64le",
+            TargetArch::riscv64gc => "riscv64",
+            TargetArch::x86 => "i386",
+            TargetArch::arm_hf => "armv7hl",
+            TargetArch::arm => "armv7l",
+            TargetArch::Other(arch) => arch,
+        }
+    }
+}


### PR DESCRIPTION
This PR first adds the ability to pass rust target from command-line, during rpm build.

Example:
```
cargo rpm build --target x86_64-unknown-linux-gnu
```

The target value gets used by cargo during project build. This is similar to the behavior of `target` as part of [package.metadata.rpm.cargo] from Cargo.toml (introduced as part of https://github.com/iqlusioninc/cargo-rpm/pull/24), but the commandline arg now allows rpm packaging for multiple rust targets without needing to edit Cargo.toml for every target.

When target is specified from both commandline and Cargo.toml, the value passed from commandline takes precedence -- the entry in Cargo.toml can be now taken a default target value for rpm packaging (and which can be overridden from commandline).

---

Secondly, this PR tries to automatically infer rpm target architecture from the rust target (either coming from Cargo.toml or the newly introduced command-line flag).

If rpm `target_architecture` is already specified from Cargo.toml, as part of [package.metadata.rpm] (ability introduced in https://github.com/iqlusioninc/cargo-rpm/pull/49), that value takes precedence.

Also added logging to make it clear how rpm target architecture gets set ultimately.

---

The changes here should resolve the issue https://github.com/iqlusioninc/cargo-rpm/issues/47 (if I'm understanding the need there correctly). 

Also at some point, `target_architecture` can probably be removed from [package.metadata.rpm] for configuration simplicity, if the strategy chosen here turns out to be sufficient for real-world needs.

Feel free to let me know anything else I should address here. Thanks! 