### PR TITLE
v0.8.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.0 (2020-07-09)
+### Added
+- Ability to write the final rpm to a custom path ([#71])
+- Post header in spec template ([#69])
+- Option to disable `cargo build` during RPM builds ([#66])
+- Support for RPM packages with different names than the crate name ([#55])
+- Support for `--target` when cross compiling ([#49])
+- Support for directories in `[rpm.files]` ([#48])
+
+### Changed
+- Bump `handlebars` dependency to v3.0 ([#76])
+- Bump `abscissa` dependency to v0.5 ([#73])
+- Improved Rust target passing and RPM target architecture determination ([#70])
+- MSRV 1.41+ ([#68])
+- Use `cargo_metadata` to detect target directory ([#46], [#75])
+
+### Fixed
+- Error when adding a folder to `files` ([#59])
+
+[#76]: https://github.com/RustRPM/cargo-rpm/pull/76
+[#75]: https://github.com/RustRPM/cargo-rpm/pull/75
+[#73]: https://github.com/RustRPM/cargo-rpm/pull/73
+[#71]: https://github.com/RustRPM/cargo-rpm/pull/71
+[#70]: https://github.com/RustRPM/cargo-rpm/pull/70
+[#69]: https://github.com/RustRPM/cargo-rpm/pull/69
+[#68]: https://github.com/RustRPM/cargo-rpm/pull/68
+[#66]: https://github.com/RustRPM/cargo-rpm/pull/66
+[#59]: https://github.com/RustRPM/cargo-rpm/pull/59
+[#55]: https://github.com/RustRPM/cargo-rpm/pull/55
+[#49]: https://github.com/RustRPM/cargo-rpm/pull/49
+[#48]: https://github.com/RustRPM/cargo-rpm/pull/48
+[#46]: https://github.com/RustRPM/cargo-rpm/pull/46
+
 ## 0.7.0 (2019-11-30)
 
 - Upgrade to Abscissa v0.4 ([#44])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,14 @@
 [package]
 name        = "cargo-rpm"
 description = "Build RPMs from Rust projects using Cargo workflows"
-version     = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.8.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>"]
 license     = "Apache-2.0"
 readme      = "README.md"
 edition     = "2018"
 categories  = ["command-line-utilities", "development-tools"]
 keywords    = ["rpm", "cargo", "package", "release"]
-homepage    = "https://github.com/rustrpm/cargo-rpm/"
-
-[badges]
-travis-ci = { repository = "rustrpm/cargo-rpm" }
-maintenance = { status = "passively-maintained" }
+repository  = "https://github.com/iqlusioninc/cargo-rpm"
 
 [dependencies]
 abscissa_core = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(warnings, missing_docs, trivial_casts, unused_qualifications)]
 #![forbid(unsafe_code)]
-#![doc(html_root_url = "https://docs.rs/cargo-rpm/0.6.0")]
+#![doc(html_root_url = "https://docs.rs/cargo-rpm/0.8.0")]
 
 pub mod application;
 pub mod archive;


### PR DESCRIPTION
### Added
- Ability to write the final rpm to a custom path ([#71])
- Post header in spec template ([#69])
- Option to disable `cargo build` during RPM builds ([#66])
- Support for RPM packages with different names than the crate name ([#55])
- Support for `--target` when cross compiling ([#49])
- Support for directories in `[rpm.files]` ([#48])

### Changed
- Bump `handlebars` dependency to v3.0 ([#76])
- Bump `abscissa` dependency to v0.5 ([#73])
- Improved Rust target passing and RPM target architecture determination ([#70])
- MSRV 1.41+ ([#68])
- Use `cargo_metadata` to detect target directory ([#46], [#75])

### Fixed
- Error when adding a folder to `files` ([#59])

[#76]: https://github.com/RustRPM/cargo-rpm/pull/76
[#75]: https://github.com/RustRPM/cargo-rpm/pull/75
[#73]: https://github.com/RustRPM/cargo-rpm/pull/73
[#71]: https://github.com/RustRPM/cargo-rpm/pull/71
[#70]: https://github.com/RustRPM/cargo-rpm/pull/70
[#69]: https://github.com/RustRPM/cargo-rpm/pull/69
[#68]: https://github.com/RustRPM/cargo-rpm/pull/68
[#66]: https://github.com/RustRPM/cargo-rpm/pull/66
[#59]: https://github.com/RustRPM/cargo-rpm/pull/59
[#55]: https://github.com/RustRPM/cargo-rpm/pull/55
[#49]: https://github.com/RustRPM/cargo-rpm/pull/49
[#48]: https://github.com/RustRPM/cargo-rpm/pull/48
[#46]: https://github.com/RustRPM/cargo-rpm/pull/46