### PR TITLE
Forward error message from failed cargo-metadata

### DIFF
--- a/src/target.rs
+++ b/src/target.rs
@@ -19,7 +19,7 @@ pub fn find_dir() -> Result<PathBuf, Error> {
     cargo_metadata::MetadataCommand::new()
         .exec()
         .map(|metadata| metadata.target_directory)
-        .map_err(|_| format_err!(ErrorKind::Target, "couldn't find target directory!").into())
+        .map_err(|err| format_err!(ErrorKind::Target, "failed to fetch metadata: {}", err).into())
 }
 
 /// Target types we can autodetect


### PR DESCRIPTION
`cargo-metadata` may fail for different reasons and without forwarding its error message it's hard to understand what went wrong. Particularly, I had a case with a mis-configured private registry, with this patch the error looks much better:

```
error: error finding target directory: target error: failed to fetch metadata: Error during execution of `cargo metadata`: error: failed to parse manifest at <full_path_of_cargo_toml>

Caused by:
  no index found for registry: <registry_name>
```