### PR TITLE
Allow duplicate commands in build_hooks

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -172,7 +172,7 @@ impl Builder {
 
     /// Launch commands after `cargo build`  
     fn build_hooks(&self) -> Result<(), Error> {
-        if let Some(hooks) = self.rpm_metadata().build_hooks.as_ref() {
+        for hooks in &self.rpm_metadata().build_hooks {
             for (cmd, args) in hooks {
                 status_info!("Launching", "build hook \"{}\"", cmd);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,8 @@ pub struct RpmConfig {
     pub files: Option<BTreeMap<String, FileConfig>>,
 
     /// Extra commands to launch after building
-    pub build_hooks: Option<BTreeMap<String, Vec<String>>>,
+    #[serde(default = "Vec::new")]
+    pub build_hooks: Vec<BTreeMap<String, Vec<String>>>,
 
     /// Target architecture passed to `rpmbuild`
     pub target_architecture: Option<String>,


### PR DESCRIPTION
This allows the same command to be run multiple times. For example:
```toml
[[package.metadata.rpm.build_hooks]]
ls = ["-a", "-l"]

[[package.metadata.rpm.build_hooks]]
ls = ["-a"]
```