### PR TITLE
Add support for using custom config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ This will create a `.rpm/YOURCRATENAME.spec` file which is passed to the
 it may need some customization if the resulting RPM has dependencies or
 files other than target binaries.
 
+You can also specify the `--output` argument to save the `.spec` file into
+a different directory. However, you will then also need to add `config` entry
+in the `[package.metadata.rpm]` section of the `Cargo.toml` file pointing to
+that directory, or run `build` command with `--config` argument.
+
 For more information on spec files, see:
 <http://ftp.rpm.org/max-rpm/s1-rpm-build-creating-spec-file.html>
 
@@ -37,7 +42,20 @@ targets for your project and package them into an RPM.
 If you encounter errors, you may need to see more information about why
 `rpmbuild` failed. Run `cargo rpm build -v` to enable verbose mode.
 
-Finished `.rpm` files will be placed in `target/release/rpmbuild/RPMs/<arch>`
+Finished `.rpm` files will be placed in `target/release/rpmbuild/RPMs/<arch>`.
+
+You can also specify the `--output` argument (or add the `output` entry in `Cargo.lock`)
+to change the location of `.rpm` file. It can either be a file or a directory:
+
+*  If the arg value ends in a `/` (or if it is already an existent directory), the value
+   is treated as a directory path and rpm is created inside it with the default naming
+   scheme (`<name>-<version>-<release>.<arch>.rpm`).
+* For other arg values, the value is treated as a file path (the default naming scheme
+  _won't_ be followed in this case).
+* Both relative and absolute paths work as input (relative paths will be normalized to
+  be absolute when passing over to `rpmbuild`).
+* Parent directories in the path are auto-created, if not present (this is handled by
+  `rpmbuild`).
 
 ## License
 

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -24,6 +24,10 @@ pub struct BuildCmd {
     #[options(long = "target")]
     pub target: Option<String>,
 
+    /// Location to the rpm config directory
+    #[options(long = "config")]
+    pub config: Option<String>,
+
     /// Output path for the built rpm (either a file or directory)
     #[options(long = "output")]
     pub output: Option<String>,
@@ -34,37 +38,66 @@ impl Runnable for BuildCmd {
     fn run(&self) {
         // Calculate paths relative to the current directory
         let crate_root = PathBuf::from(".");
-        let rpm_config_dir = crate_root.join(RPM_CONFIG_DIR);
+        let mut rpm_config_dir = crate_root.join(RPM_CONFIG_DIR);
 
         // Read Cargo.toml
         let config = app_config();
+        let config = config.package();
         let target_dir = target::find_dir().unwrap_or_else(|e| {
             status_err!("error finding target directory: {}", e);
             process::exit(1);
         });
+
+        let mut output_path = None;
+
+        // Set config and output directories from Cargo.toml
+        if let Some(config_dir) = config.rpm_metadata().and_then(|rpm| rpm.config.as_ref()) {
+            rpm_config_dir = crate_root.join(config_dir);
+        }
+        if let Some(output_dir) = config.rpm_metadata().and_then(|rpm| rpm.output.as_ref()) {
+            output_path = Some(crate_root.join(output_dir).display().to_string());
+        }
+
+        // Set config directory from argument and convert it to an absolute path
+        if let Some(config_path) = &self.config {
+            let current_dir = env::current_dir().unwrap_or_else(|err| {
+                status_err!("{}", err);
+                process::exit(1);
+            });
+
+            // Similar logic as below for output path
+            rpm_config_dir = current_dir.join(config_path);
+        }
 
         // Convert the specified output path string to an absolute path. This
         // ensures that when relative paths are specified as cargo rpm output,
         // rpmbuild respects it (this path ultimately gets passed to rpmbuild
         // and if we don't do this, rpmbuild would put the rpm relative to
         // %{_topdir}, when relative paths are specified here).
-        let output_path_absolute = self.output.as_ref().map(|path_string| {
-            let mut p = env::current_dir().unwrap_or_else(|err| {
+        let convert_to_absolute = |path_string| {
+            let mut absolute = env::current_dir().unwrap_or_else(|err| {
                 status_err!("{}", err);
                 process::exit(1);
             });
-            // If path_string is already absolute, p becomes that. Otherwise
-            // current dir is prepended to the path_string.
-            p.push(path_string);
-            p.display().to_string()
-        });
+            // If `path_string` is already absolute, `absolute` becomes that. Otherwise
+            // current dir is prepended to the `path_string`.
+            absolute.push(path_string);
+            absolute.display().to_string()
+        };
+
+        // Set the output path from argument or Cargo.toml
+        if self.output.is_some() {
+            output_path = self.output.as_ref().map(convert_to_absolute);
+        } else {
+            output_path = output_path.as_ref().map(convert_to_absolute);
+        }
 
         Builder::new(
-            config.package(),
+            config,
             self.verbose,
             self.no_cargo_build,
             self.target.as_ref(),
-            output_path_absolute.as_ref(),
+            output_path.as_ref(),
             &rpm_config_dir,
             &target_dir,
         )

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,13 +106,19 @@ pub struct RpmConfig {
     /// The RPM package name, if different from crate name
     pub package: Option<String>,
 
+    /// Config directory, defaults to `.rpm`
+    pub config: Option<String>,
+
+    /// Output directory or file, defaults to `target/release/rpmbuild/RPMs`
+    pub output: Option<String>,
+
     /// Options for creating the release artifact
     pub cargo: Option<CargoFlags>,
 
     /// Target configuration: a map of target binaries to their file config
     pub targets: BTreeMap<String, FileConfig>,
 
-    /// Extra files (taken from the `.rpm` directory) to include in the RPM
+    /// Extra files (taken from the config directory) to include in the RPM
     pub files: Option<BTreeMap<String, FileConfig>>,
 
     /// Extra commands to launch after building


### PR DESCRIPTION
This implements support for setting a custom config (`.rpm`) directory in `Cargo.toml` or as a `cargo rpm build --config` argument, and closes #72. If both `Cargo.toml` entry and argument are specified, the argument value will be used.

I also added support to change RPM output directory (that was implemented in #71) using `Cargo.toml` entry, and the same priority rules apply.