### PR TITLE
Fix crash during rpmbuild version parsing

### DIFF
--- a/src/rpmbuild.rs
+++ b/src/rpmbuild.rs
@@ -79,7 +79,7 @@ impl Rpmbuild {
         }
 
         let parts: Vec<&str> = vers.split_whitespace().collect();
-        Ok(parts[2].to_owned())
+        Ok(parts[parts.len() - 1].to_owned())
     }
 
     /// Execute `rpmbuild` with the given arguments


### PR DESCRIPTION
When running with german locale, the output of `rpmbuild --version` is `RPM-Version 4.16.1.3`
instead of `RPM version 4.16.1.3` for en_US locale.