### PR TITLE
Detect targets using cargo metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ handlebars = "3"
 serde = { version = "1", features = ["serde_derive"] }
 tar = "0.4"
 thiserror = "1"
-cargo_metadata = "0.10"
+cargo_metadata = "0.14"
 
 [dev_dependencies]
 abscissa_core = { version = "0.5", features = ["testing"] }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -5,6 +5,7 @@ use crate::{
     error::{Error, ErrorKind},
     license,
     prelude::*,
+    target::Target,
 };
 use handlebars::Handlebars;
 use serde::Serialize;
@@ -38,7 +39,13 @@ pub struct SpecParams {
     /// Name of a systemd service unit (if enabled)
     pub service: Option<String>,
 
-    /// Are we placing targets in sbin instead of bin?
+    /// Are we creating any binary executables?
+    pub bin: bool,
+
+    /// Are we creating any libraries?
+    pub lib: bool,
+
+    /// Are we placing executables in sbin instead of bin?
     pub use_sbin: bool,
 }
 
@@ -49,6 +56,7 @@ impl SpecParams {
         package: &PackageConfig,
         service: Option<String>,
         use_sbin: bool,
+        targets: &[Target],
     ) -> Self {
         let rpm_license = license::convert(&package.license).unwrap_or_else(|e| {
             let default_lic = match package.license {
@@ -66,6 +74,12 @@ impl SpecParams {
             url: package.homepage.to_owned(),
             service,
             use_sbin,
+            bin: targets
+                .iter()
+                .any(|target| matches!(target, Target::Bin(_))),
+            lib: targets
+                .iter()
+                .any(|target| matches!(target, Target::Cdylib(_))),
         }
     }
 

--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -54,10 +54,15 @@ rm -rf %{buildroot}
 
 %files
 %defattr(-,root,root,-)
+{{#if bin ~}}
 {{#if use_sbin ~}}
 %{_sbindir}/*
 {{else ~}}
 %{_bindir}/*
+{{/if ~}}
+{{/if ~}}
+{{#if lib ~}}
+%{_libdir}/*
 {{/if ~}}
 {{#if service ~}}
 %{_unitdir}/{{service}}

--- a/tests/acceptance.rs
+++ b/tests/acceptance.rs
@@ -10,7 +10,7 @@
 use abscissa_core::testing::prelude::*;
 use once_cell::sync::Lazy;
 
-pub static RUNNER: Lazy<CmdRunner> = Lazy::new(|| CmdRunner::default());
+pub static RUNNER: Lazy<CmdRunner> = Lazy::new(CmdRunner::default);
 
 /// Test the `cargo rpm version` subcommand
 #[test]


### PR DESCRIPTION
Fixes https://github.com/iqlusioninc/cargo-rpm/issues/54

I'm trying to use `cargo-rpm` on a couple of Rust projects that either produce a cdylib, or have a subdirectory in src/bin/. I've updated `cargo-rpm` to use `cargo_metadata` to detect targets, per the suggestion in https://github.com/iqlusioninc/cargo-rpm/pull/53#issuecomment-614881116, which enables both.

Open to suggestions on how to add tests for this. I could create some Cargo.toml test fixtures and check they are modified as expected by `cargo rpm -init`?